### PR TITLE
README: note that llvm-3.3 should be installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This library provides a simple interface to the SIMD primops provided in GHC 7.8
 SIMD (Single Instruction Multiple Data) CPU instructions provide an easy way to parallelize numeric computations. 
 GHC 7.8 provides primops that let us access these CPU instructions. 
 This package wraps thos primops in a more user friendly form.
-These primops can only be used with the llvm backend, so you must have llvm installed and compile any program using this library with the -llvm option.
+These primops can only be used with the llvm backend, so you must have llvm-3.3 installed and compile any program using this library with the -llvm option.
 
 This library [is available on hackage](http://hackage.haskell.org/package/simd), and so can be installed by:
     


### PR DESCRIPTION
I tried installing simd with llvm-3.4, 3.5, and 3.6 and was only able to install with llvm-3.3.
