### PR TITLE
Fix problems with unVectorizeUnboxedX

### DIFF
--- a/src/Data/SIMD/SIMD16.hs
+++ b/src/Data/SIMD/SIMD16.hs
@@ -331,9 +331,9 @@ vectorizeUnboxedX16 v = if len `mod` 16 == 0 && off `mod` 16 == 0
 -- | converts an unboxed SIMD vector into a standard unboxed vector
 {-# INLINE unVectorizeUnboxedX16 #-}
 unVectorizeUnboxedX16 :: (SIMD16 a, VU.Unbox a) => VU.Vector (X16 a) -> VU.Vector a
-unVectorizeUnboxedX16 v = unsafeCoerce v
+unVectorizeUnboxedX16 v = unsafeCoerce pv
     where
-        pv = UnsafePrimVector (len*16) (off*16)
+        pv = UnsafePrimVector (len*16) (off*16) arr
         UnsafePrimVector len off arr = unsafeCoerce v
 
 -- | converts a storable vector into one that will use the SIMD instructions

--- a/src/Data/SIMD/SIMD2.hs
+++ b/src/Data/SIMD/SIMD2.hs
@@ -328,9 +328,9 @@ vectorizeUnboxedX2 v = if len `mod` 2 == 0 && off `mod` 2 == 0
 -- | converts an unboxed SIMD vector into a standard unboxed vector
 {-# INLINE unVectorizeUnboxedX2 #-}
 unVectorizeUnboxedX2 :: (SIMD2 a, VU.Unbox a) => VU.Vector (X2 a) -> VU.Vector a
-unVectorizeUnboxedX2 v = unsafeCoerce v
+unVectorizeUnboxedX2 v = unsafeCoerce pv
     where
-        pv = UnsafePrimVector (len*2) (off*2)
+        pv = UnsafePrimVector (len*2) (off*2) arr
         UnsafePrimVector len off arr = unsafeCoerce v
 
 -- | converts a storable vector into one that will use the SIMD instructions

--- a/src/Data/SIMD/SIMD4.hs
+++ b/src/Data/SIMD/SIMD4.hs
@@ -386,9 +386,9 @@ vectorizeUnboxedX4 v = if len `mod` 4 == 0 && off `mod` 4 == 0
 -- | converts an unboxed SIMD vector into a standard unboxed vector
 {-# INLINE unVectorizeUnboxedX4 #-}
 unVectorizeUnboxedX4 :: (SIMD4 a, VU.Unbox a) => VU.Vector (X4 a) -> VU.Vector a
-unVectorizeUnboxedX4 v = unsafeCoerce v
+unVectorizeUnboxedX4 v = unsafeCoerce pv
     where
-        pv = UnsafePrimVector (len*4) (off*4)
+        pv = UnsafePrimVector (len*4) (off*4) arr
         UnsafePrimVector len off arr = unsafeCoerce v
 
 -- | converts a storable vector into one that will use the SIMD instructions

--- a/src/Data/SIMD/SIMD8.hs
+++ b/src/Data/SIMD/SIMD8.hs
@@ -386,9 +386,9 @@ vectorizeUnboxedX8 v = if len `mod` 8 == 0 && off `mod` 8 == 0
 -- | converts an unboxed SIMD vector into a standard unboxed vector
 {-# INLINE unVectorizeUnboxedX8 #-}
 unVectorizeUnboxedX8 :: (SIMD8 a, VU.Unbox a) => VU.Vector (X8 a) -> VU.Vector a
-unVectorizeUnboxedX8 v = unsafeCoerce v
+unVectorizeUnboxedX8 v = unsafeCoerce pv
     where
-        pv = UnsafePrimVector (len*8) (off*8)
+        pv = UnsafePrimVector (len*8) (off*8) arr
         UnsafePrimVector len off arr = unsafeCoerce v
 
 -- | converts a storable vector into one that will use the SIMD instructions


### PR DESCRIPTION
Hi! I noticed a problem in `unVectorizeUnboxedX_` while using the library. The problem stemmed from calling unsafeCoerce on `v` as opposed to `pv` in `unVectorizeUnboxedX_`, and not fully constructing the UnsafePrimitiveArray for `pv` (failing to pass it `arr`). This was causing problems such as:

```
unVectorizeUnboxedX4 $ vectorizeUnboxedX4 $ VU.fromList [1,2,3,4]
fromList [1.0]
```

This pull request fixes this problem, and it now returns `fromList [1.0,2.0,3.0,4.0]` as it should.
